### PR TITLE
fix: Handle exceptions in RefreshLocationInfo

### DIFF
--- a/Helpers/Methods.cs
+++ b/Helpers/Methods.cs
@@ -1,3 +1,4 @@
+using System;
 using Comfort.Common;
 using EFT;
 using EFT.Communications;
@@ -24,9 +25,14 @@ namespace MOAR.Helpers
 
         public static async void RefreshLocationInfo()
         {
-            if (PatchConstants.BackEndSession != null)
-                await PatchConstants.BackEndSession.GetLevelSettings();
-            // await PatchConstants.BackEndSession.GetWeatherAndTime();
+            try {
+                if (PatchConstants.BackEndSession != null)
+                    await PatchConstants.BackEndSession.GetLevelSettings();
+                // await PatchConstants.BackEndSession.GetWeatherAndTime();
+            } catch (Exception e) {
+                Plugin.LogSource.LogError(
+                    "[HANDLED] General exception in RefreshLocationInfo");
+            }
         }
 
         public static AddSpawnRequest GetPlayersCoordinatesAndLevel()


### PR DESCRIPTION
GetLevelSettings internally throws Exception when the task fails. If we don't handle it here the game will crash.

Fixes #9 temporarily. I believe the bug I was experiencing was some very weird internal client-server connection failure or something. Even so, not crashing the game anyway is a nice perk.